### PR TITLE
Specify files to publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "chai": "^3.4.1",
     "chai-as-promised": "^5.1.0",
     "es6-shim": "^0.33.13"
-  }
+  },
+  "files": [
+    "index.js"
+  ]
 }


### PR DESCRIPTION
Currently `test` folder and `.travis.yml` are being published to npm. Considering that they make this package a bit larger, it would be worthwhile to exclude them.

This PR excludes them using the using the [`files`](https://docs.npmjs.com/files/package.json#files) whitelist in the `package.json`.